### PR TITLE
Make uninstall yes/no prompt consistent with others

### DIFF
--- a/plugins/python-build/bin/pyenv-uninstall
+++ b/plugins/python-build/bin/pyenv-uninstall
@@ -75,7 +75,7 @@ uninstall-python() {
       exit 1
     fi
 
-    read -p "pyenv: remove $PREFIX? [y|N] "
+    read -p "pyenv: remove $PREFIX? (y/N) "
     case "$REPLY" in
     y | Y | yes | YES ) ;;
     * ) exit 1 ;;


### PR DESCRIPTION
The uninstall yes/no prompt used "[y|N]", whereas others in [`pyenv`](https://github.com/search?q=repo%3Apyenv%2Fpyenv+%2F%5B%5C%28%5C%5B%5Dy%5B%5C%2F%5C%7C%5Dn%2F&type=code) and [`pyenv-virtualenv`](https://github.com/search?q=repo%3Apyenv%2Fpyenv-virtualenv+%2F%5B%5C%28%5C%5B%5Dy%5B%5C%2F%5C%7C%5Dn%2F&type=code) use "(y/N)".
This PR updates it to be consistent with the others.
